### PR TITLE
Mssql support

### DIFF
--- a/dataduct/etl/etl_pipeline.py
+++ b/dataduct/etl/etl_pipeline.py
@@ -53,11 +53,11 @@ QA_LOG_PATH = config.etl.get('QA_LOG_PATH', const.QA_STR)
 DP_INSTANCE_LOG_PATH = config.etl.get('DP_INSTANCE_LOG_PATH', const.NONE)
 DP_PIPELINE_LOG_PATH = config.etl.get('DP_PIPELINE_LOG_PATH', const.NONE)
 
-DEFAULT_TEARDOWN = {
+DEFAULT_TEARDOWN = [{
     'step_type': 'transform',
     'command': 'echo Finished Pipeline',
     'no_output': True
-}
+}]
 
 
 class ETLPipeline(object):
@@ -252,18 +252,11 @@ class ETLPipeline(object):
                 'no_output': True,
                 'name': 'system-bootstrap-config-sig-version'
                 }
-        sleeping = {
-                'step_type': 'transform',
-                'command': "tail -f /dev/null",
-                'no_output': True,
-                'name': 'system-sleeper'
-                }
 
         for resource_type in [const.EC2_RESOURCE_STR, const.EMR_CLUSTER_STR]:
             if resource_type in self.bootstrap_definitions:
                 config_sig_version['resource_type'] = resource_type
                 self.bootstrap_definitions[resource_type].insert(0,config_sig_version)
-                self.bootstrap_definitions[resource_type].insert(1,sleeping)
 
     def set_up_ssh_tunnels(self):
         ssh_commands = []
@@ -649,7 +642,7 @@ class ETLPipeline(object):
     def create_teardown_step(self):
         """Create teardown steps for the pipeline
         """
-        return self.create_steps([self.teardown_definition], is_teardown=True)
+        return self.create_steps(self.teardown_definition, is_teardown=True)
 
     def create_bootstrap_steps(self, resource_type):
         """Create the boostrap steps for installation on all machines

--- a/dataduct/etl/etl_pipeline.py
+++ b/dataduct/etl/etl_pipeline.py
@@ -11,7 +11,6 @@ from datetime import datetime
 from datetime import timedelta
 from itertools import chain
 from urlparse import urlparse
-from IPython import embed
 
 from ..config import Config
 from .utils import process_steps

--- a/dataduct/pipeline/__init__.py
+++ b/dataduct/pipeline/__init__.py
@@ -7,7 +7,9 @@ from .emr_resource import EmrResource
 from .emr_activity import EmrActivity
 from .mysql_node import MysqlNode
 from .postgres_node import PostgresNode
+from .mssql_node import MssqlNode
 from .postgres_database import PostgresDatabase
+from .mssql_database import MssqlDatabase
 from .pipeline_object import PipelineObject
 from .precondition import Precondition
 from .redshift_copy_activity import RedshiftCopyActivity

--- a/dataduct/pipeline/mssql_database.py
+++ b/dataduct/pipeline/mssql_database.py
@@ -1,0 +1,54 @@
+"""
+Pipeline object class for MsSql Jdbc database
+see http://docs.aws.amazon.com/datapipeline/latest/DeveloperGuide/dp-object-jdbcdatabase.html
+"""
+
+from ..config import Config
+from .pipeline_object import PipelineObject
+from ..utils.exceptions import ETLConfigError
+
+config = Config()
+if not hasattr(config, 'mssql'):
+    raise ETLConfigError('MSSQL credentials missing from config')
+
+class MssqlDatabase(PipelineObject):
+    """Jdbc resource class
+    """
+
+    def __init__(self,
+                 id,
+                 host=None,
+                 port=None,
+                 database=None,
+                 username=None,
+                 jdbc_driver_uri=None,
+                 password=None):
+        """Constructor for the MSSQL class
+
+        Args:
+            id(str): id of the object
+            host(str): 
+            port(str): 
+            database(str): 
+            jdbc_driver_uri(str): 
+            username(str): username for the database
+            password(str): password for the database
+        """
+
+        if (None in [ jdbc_driver_uri, username, password]):
+            raise ETLConfigError('MSSQL credentials missing from config')
+
+        connection_string = "jdbc:sqlserver://" + host + ":" + str(port) + ";database=" + database + ";"
+        jdbc_driver_class = "com.microsoft.sqlserver.jdbc.SQLServerDriver"
+
+        kwargs = {
+            'id': id,
+            'type': 'JdbcDatabase',
+            'connectionString': connection_string,
+            'jdbcDriverClass': jdbc_driver_class,
+            'jdbcDriverJarUri': jdbc_driver_uri,
+            'username': username,
+            '*password': password,
+        }
+        super(MssqlDatabase, self).__init__(**kwargs)
+

--- a/dataduct/pipeline/mssql_node.py
+++ b/dataduct/pipeline/mssql_node.py
@@ -1,0 +1,44 @@
+"""
+Pipeline object class for SqlNode
+"""
+
+from ..utils.exceptions import ETLInputError
+from .pipeline_object import PipelineObject
+from .schedule import Schedule
+
+
+class MssqlNode(PipelineObject):
+    """SQL Data Node class
+    """
+
+    def __init__(self, id, schedule, host, database, username, password,
+                 select_query, insert_query, table, depends_on=None):
+        """Constructor for the SqlNode class
+
+        Args:
+            id(str): id of the object
+            schedule(Schedule): pipeline schedule
+            database(MssqlDatabase): database name on the RDS host
+            sql(str): sql to be executed
+            table(str): table to be read
+        """
+
+        # Validate inputs
+        if not isinstance(schedule, Schedule):
+            raise ETLInputError(
+                'Input schedule must be of the type Schedule')
+
+        if not depends_on:
+            depends_on = list()
+
+        kwargs = {
+            'id': id,
+            'type': 'SqlDataNode',
+            'schedule': schedule,
+            'database': database,
+            'selectQuery': select_query,
+            'insertQuery': insert_query,
+            'table': table,
+            'dependsOn': depends_on,
+        }
+        super(MssqlNode, self).__init__(**kwargs)

--- a/dataduct/steps/pipeline_dependencies.py
+++ b/dataduct/steps/pipeline_dependencies.py
@@ -87,7 +87,14 @@ class PipelineDependenciesStep(TransformStep):
             step_args(dict): Dictionary of the step arguments for the class
         """
         input_args = cls.pop_inputs(input_args)
-        step_args = cls.base_arguments_processor(etl, input_args)
+
+        if input_args.pop('resource_type', None) == const.EMR_CLUSTER_STR:
+            resource_type = const.EMR_CLUSTER_STR
+        else:
+            resource_type = const.EC2_RESOURCE_STR
+
+        step_args = cls.base_arguments_processor(etl, input_args, resource_type=resource_type)
         step_args['pipeline_name'] = etl.name
+
 
         return step_args


### PR DESCRIPTION
Adds initial support for MSSQL imports
Adds support for running ssh tunnels, spun up by the workergroup
changes default teardown to a list, to more closely match how bootstrap steps and regular steps are handled
Allows pipeline dependencies to run on either EMR or EC2 resources (previously defaulted to ec2 in all cases)
DP-416, DP-378, DP-379