### PR TITLE
DP-649-allow-script-text

### DIFF
--- a/dataduct/pipeline/sql_activity.py
+++ b/dataduct/pipeline/sql_activity.py
@@ -48,9 +48,6 @@ class SqlActivity(Activity):
             raise ETLInputError(
                 'Input schedule must be of the type Schedule')
 
-        if not isinstance(script, S3File):
-            raise ETLInputError('script must be an S3File')
-
         # Set default values
         if depends_on is None:
             depends_on = []
@@ -66,8 +63,13 @@ class SqlActivity(Activity):
             runsOn=resource,
             workerGroup=worker_group,
             schedule=schedule,
-            scriptUri=script,
             scriptArgument=script_arguments,
             database=database,
             queue=queue
         )
+        if isinstance(script, str):
+            self.fields['script'] = [script]
+        elif isinstance(script, S3File):
+            self.fields['scriptUri'] = [script]
+        else:
+            raise ETLInputError('script must be an S3File or a string sql statement')

--- a/dataduct/steps/sql_command.py
+++ b/dataduct/steps/sql_command.py
@@ -20,6 +20,7 @@ class SqlCommandStep(ETLStep):
     def __init__(self,
                  redshift_database,
                  script=None,
+                 script_file=None,
                  script_arguments=None,
                  queue=None,
                  sql_script=None,
@@ -45,15 +46,20 @@ class SqlCommandStep(ETLStep):
         super(SqlCommandStep, self).__init__(**kwargs)
 
         # Create S3File with script / command provided
-        if script:
+        if script_file:
             sql_script = SqlScript(filename=parse_path(script))
+        elif script:
+            sql_script = SqlScript(script)
         elif command:
             sql_script = SqlScript(command)
 
         if wrap_transaction:
             sql_script = sql_script.wrap_transaction()
 
-        script = self.create_script(S3File(text=sql_script.sql()))
+        if script:
+            script = sql_script.sql()
+        else:
+            script = self.create_script(S3File(text=sql_script.sql()))
 
         logger.debug('Sql Query:')
         logger.debug(sql_script)


### PR DESCRIPTION
update to set 'script' to refer to text rather than an s3 file. Necessary because you can use params with scripts, but not s3files in sqlactivity