### PR TITLE
DP-1296-Initial Datadog Metrics

### DIFF
--- a/dataduct/pipeline/sns_alarm.py
+++ b/dataduct/pipeline/sns_alarm.py
@@ -38,14 +38,17 @@ class SNSAlarm(PipelineObject):
                  'pipeline_object': '#{node.name}',
                  'schedule_start_time': '#{node.@scheduledStartTime}',
                  'error_message': '#{node.errorMessage}',
-                 'error_stack_trace': '#{node.errorStackTrace}'
+                 'error_stack_trace': '#{node.errorStackTrace}',
+                 'pipeline_id': '#{node.@pipelineId}'
+
         }
 
         default_success_message = {
                  'pipeline_object': '#{node.name}',
                  'pipeline_object_scheduled_start_time': '#{node.@scheduledStartTime}',
                  'pipeline_object_actual_start_time': '#{node.@actualStartTime}',
-                 'pipeline_object_actual_end_time': '#{node.@actualEndTime}'
+                 'pipeline_object_actual_end_time': '#{node.@actualEndTime}',
+                 'pipeline_id': '#{node.@pipelineId}'
         }
 
         if failure:


### PR DESCRIPTION
This PR is changing SNS default message to add the pipeline_id.
This id will be sent on the sns message and will be taken by the metrics lambda function in order to request the information to Datapipeline API.